### PR TITLE
New readme, dirs for ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,21 @@
 # D Project Idea repository
+This repository is a collection of ideas for projects that will enhance the D ecosystem. Anyone in the D community may submit an idea. Projects may be picked up by anyone looking to contribute to the D ecosystem, but some may be flagged as suitable for the annual Symmetry Autumn of Code (SAOC) or Google Summer of Code (GSOC). Anyone intending to apply to either event may find a suitable project here.
 
-This repository hosts and organises a list of impactful projects in the D ecosystem.
-The previously used vision document is superseeded by the continous, changing vision build up from the milestones of this repo.
+There are two sets of projects:
 
-## [Browse project ideas](https://github.com/dlang/projects/issues)
+1. A curated list that has been given the stamp of approval by the DLF. Projects in this set are deemed to align with the DLF's current goals for the language, the ecosystem, or the community. Projects in this category are described in documents that reside in one of the directories in this repository. Projects suitable for SAOC are under the `saoc` directory, and those for GSOC in the `gsoc` directory.
+2. A mostly uncurated list of projects that have not yet received the blessing of the DLF. This does not mean the projects aren't worth doing, only that they may not align with the DLF's current goals, or they haven't yet been properly evaluated. Projects in this set that are found [in this repository's issue tracker](https://github.com/dlang/projects/issues). Projects sutiable for either SAOC or GSOC are tagged with a label indicating such.
 
-Note: some of these projects are not necessarily endorsed by the D Language Foundation. Endorsed projects are marked with the "vision" label.
+## Submitting a project
 
-Everyone is welcome to submit new project ideas. However, please keep in mind that this repository tries to collect high-level goals and project. A good rule of thumb is that if a project can't be split into smaller parts, it might belong to its respective issue tracker.
+Everyone is welcome to submit new project ideas to [the issues list](https://github.com/dlang/projects/issues). Generally, there is no requirement that proposed projects meet requirements for any sort of time period except when considering the projects are suitable for SAOC or GSOC. Projects suitable for SAOC should keep someone busy for 20 hours/week for four months. Projects suitable for GSOC should keep someone occupied for 10&ndash;22 weeks, with 12 weeks being the ideal.
 
-Bad Example: Fix Issue 12345 in DMD
+Projects proposals should be as descriptive as possible. Each proposal should contain:
 
-Good Example: Improve DMD user experience on Windows (includes a list of issues)
-
-## Voting
-
-As projects are suggested by individual people, it's hard to judge how important they are to community. Hence, please vote on them via GitHub reactions as this helps us a lot in priotizing issues.
-
-## Leadership vision projects
-
-Projects marked with the "leadership vision" label are vision projects of the D Language Foundation.
-These projects are seen as key projects to D's success by the leadership.
-
-## Milestones
-
-[Milestones](https://github.com/dlang/projects/milestones) are used to group project ideas and keep track of them.
-
-### University thesis
-
-If you are a student and are interesting in working on a project idea for your thesis, please do not hesitate to leave a comment on the issue and/or contact the persons mentioned in the respective issue.
-
-### GSoC and SAoC
-
-Many of the listed projects are suitable for the Google Summer of Code (GSoC) or Symmetry Autumn of Code (SAoC). Before this programs, we will tag some of the projects with "gsoc". This implies that we think these projects are well suited for the respective programs. This doesn't mean that non-tagged projects are necessarily a bad fit for a GSoC/SAoC. In doubt, ask on the respective issue or the GSoC/SAoC program admins.
+* A title that indicates the end goal of the project. This goes in the title field of the issue or PR, and should also be included as the first line of any proposal document submitted as a pull request.
+* A 'Description' section that provides as much detail as necessary for someone to get up and running.
+* A section of rough milestones that provide further context on the project's purpose.
+* A section describing the expected outcome.
+* A section describing the recommended skills necessary to complete the project.
+* If the project is intended for SAOC or GSOC, an optional section listing any potential mentors who have at least tentatively agreed to make themselves available.
+* An optional 'Getting started' section with links to any existing documentation or other references that may be helpful to anyone taking the project on.


### PR DESCRIPTION
We've decided to start curating the list of ideas by taking ideas from the issues and submitting them as documents to the repository. This PR updates the README to reflect that, and adds directories for gsoc and saoc projects.